### PR TITLE
Fixed the name of the $cityId parameter according to the documentation

### DIFF
--- a/src/Request/GetOfficesRequest.php
+++ b/src/Request/GetOfficesRequest.php
@@ -10,12 +10,12 @@ class GetOfficesRequest extends Request
     private const HTTP_METHOD = 'POST';
 
     private ?string $countryCode;
-    private ?int $cityId;
+    private ?int $cityID;
 
     public function __construct(?string $countryCode = null, ?int $cityId = null)
     {
         $this->countryCode = $countryCode;
-        $this->cityId = $cityId;
+        $this->cityID = $cityId;
     }
 
     public function getEndpoint(): string


### PR DESCRIPTION
Fixed the name of the City Id parameter according to the documentation.

According to the documentation, the parameter is called $cityID http://ee.econt.com/services/Nomenclatures/#NomenclaturesService-getOffices